### PR TITLE
Add HPC Community Engagement section and HPC.social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ If you wish to contribute to this list please raise a pull request here or drop 
 - [Inside HPC](https://insidehpc.com)
 - [Flux by HMx Labs](https://cloudhpc.news)
 - [The Forbidden Unix](https://www.linkedin.com/company/forbiddenunix/posts/?feedView=all)
+
+# HPC Community Engagement
+- [HPC.social](https://hpc.social) - [Slack](https://hpc.social/projects/chat/), [Discord](https://hpc.social/projects/chat/), [blogs](https://hpc.social/projects/blog/), [community map](https://hpc.social/map/), [Good First Issues catalog](https://hpc-social.github.io/good-first-issues/), [Mastodon](https://mast.hpc.social/), [BlueSky](https://bsky.app/profile/hpc.social), and more


### PR DESCRIPTION
Add a community engagement section and start it out with links to the many useful hpc.social pages and projects.